### PR TITLE
feat: add cookie banner

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -2,10 +2,8 @@ import "@ashgw/css/global";
 
 import type { Metadata } from "next";
 import type { PropsWithChildren } from "react";
-import { GoogleAnalytics } from "@next/third-parties/google";
 
-import { Providers } from "@ashgw/components";
-import { env } from "@ashgw/env";
+import { CookieBanner, Providers } from "@ashgw/components";
 import { createMetadata } from "@ashgw/seo";
 import { fonts } from "@ashgw/ui";
 
@@ -22,8 +20,10 @@ export default function RootLayout({ children }: PropsWithChildren) {
       <body className={fonts.atkinsonHyperlegible.className}>
         <GoBackHome />
         <Providers site="blog">{children}</Providers>
+        <div className="fixed bottom-4 right-4 max-w-[550px]">
+          <CookieBanner />
+        </div>
       </body>
-      <GoogleAnalytics gaId={env.NEXT_PUBLIC_BLOG_GOOGLE_ANALYTICS_ID} />
     </html>
   );
 }

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "@ashgw/css/global";
 import type { Metadata } from "next";
 import type { PropsWithChildren } from "react";
 
-import { Providers } from "@ashgw/components";
+import { CookieBanner, Providers } from "@ashgw/components";
 import { createMetadata } from "@ashgw/seo";
 import { fonts } from "@ashgw/ui";
 
@@ -20,6 +20,9 @@ export default function RootLayout({ children }: PropsWithChildren) {
       <body className={fonts.atkinsonHyperlegible.className}>
         <NavBar />
         <Providers site="www">{children}</Providers>
+        <div className="fixed bottom-4 right-4 max-w-[550px]">
+          <CookieBanner />
+        </div>
       </body>
     </html>
   );

--- a/packages/components/src/reusables/cookies/components/CookieBanner.css
+++ b/packages/components/src/reusables/cookies/components/CookieBanner.css
@@ -1,0 +1,15 @@
+@keyframes glow {
+  0% {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+  50% {
+    border-color: rgba(255, 255, 255, 1);
+  }
+  100% {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+}
+
+.border-glow {
+  animation: glow 1.2s infinite alternate;
+}

--- a/packages/components/src/reusables/cookies/components/CookieBanner.tsx
+++ b/packages/components/src/reusables/cookies/components/CookieBanner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { usePostHog } from "@ashgw/analytics/posthog-client";
+import { Button } from "@ashgw/ui";
+
+import "./CookieBanner.css";
+
+export const CookieBanner = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const postHog = usePostHog();
+
+  useEffect(() => {
+    if (!localStorage.getItem("cookie-consent")) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    postHog.opt_in_capturing();
+    setIsVisible(false);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 20 }}
+        transition={{ duration: 0.3 }}
+        className="border-glow rounded-3xl border border-gray-700 bg-gray-800 bg-opacity-70 p-4 shadow-md backdrop-blur-md"
+      >
+        <div className="flex flex-col gap-2">
+          <div className="text-sm text-gray-300">
+            <p>This site uses cookies. By using it, you accept cookies.</p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              onClick={handleAccept}
+              className="text-xs"
+            >
+              Ok, I got it
+            </Button>
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/packages/components/src/reusables/cookies/index.ts
+++ b/packages/components/src/reusables/cookies/index.ts
@@ -1,0 +1,1 @@
+export { CookieBanner } from "./components/CookieBanner";

--- a/packages/components/src/reusables/index.ts
+++ b/packages/components/src/reusables/index.ts
@@ -8,3 +8,4 @@ export { ErrorBoundary } from "./ErrorBoundary";
 export { Link, GlowingLink } from "./link";
 export { LoadingScreen } from "./LoadingScreen";
 export { BackUpTop } from "./BackUpTop";
+export * from "./cookies";


### PR DESCRIPTION
### TL;DR

Added a cookie consent banner to both blog and www apps for tracking.

### What changed?

- Created a new `CookieBanner` component in the components package
- Added the banner to both blog and www layouts
- Removed Google Analytics integration from the blog app
- Implemented PostHog opt-in capturing when users accept cookies
- Added animation and styling for the cookie banner with a glowing border effect

### Why make this change?

This change improves privacy compliance by explicitly requesting user consent before tracking their activity. It also transitions from Google Analytics to PostHog for analytics, providing more control over user data and respecting user preferences for tracking.