### PR TITLE
ci: add preview on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,23 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
   # This needs my manual permission to dispatch
+  preview-deployemnt:
+    if: github.ref == 'refs/heads/main'
+    needs: [mergeable]
+    uses: ./.github/workflows/on-workflow-call-preview-deployment.yml
+    secrets: inherit
+
+  www-prevew-deployemnt:
+    needs: [preview-deployemnt]
+    uses: ./.github/workflows/on-workflow-call-www-preview-deployment.yml
+    secrets: inherit
+
+  blog-preview-deployemnt:
+    needs: [preview-deployemnt]
+    uses: ./.github/workflows/on-workflow-call-blog-preview-deployment.yml
+    secrets: inherit
+
+  # same here
   production-deployemnt:
     if: github.ref == 'refs/heads/main'
     needs: [mergeable]

--- a/.github/workflows/on-workflow-call-preview-deployment.yml
+++ b/.github/workflows/on-workflow-call-preview-deployment.yml
@@ -1,0 +1,33 @@
+name: Preview Deployment
+
+on:
+  workflow_call:
+
+jobs:
+  deploy-preview:
+    environment: preview
+    name: Trigger Preview Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    concurrency:
+      group: preview-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Send Notification
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.actor
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'preview_deploy_started',
+              client_payload: {
+                message: `🚀 Preview deployment started by @${creator}`,
+                triggered_at: new Date().toISOString()
+              }
+            })
+      - name: Success
+        run: |
+          echo "::notice title=Preview Deploy::Deployment started by @${{ github.actor }} at $(date)"
+          echo "Deployment triggered successfully"


### PR DESCRIPTION
## Add Preview Deployment Workflow for Main Branch

This PR adds a preview deployment workflow that automatically runs when changes are pushed to the main branch. The implementation includes:

- Added three new preview deployment jobs to the CI workflow:
  - `preview-deployment` - Base preview deployment that runs after the mergeable check
  - `www-preview-deployment` - Website preview that depends on the base preview
  - `blog-preview-deployment` - Blog preview that depends on the base preview

- Created a new workflow file `on-workflow-call-preview-deployment.yml` that:
  - Runs in the preview environment
  - Sends a GitHub notification when preview deployment starts
  - Includes concurrency controls to prevent multiple simultaneous deployments
  - Outputs deployment status messages

These preview deployments allow the team to verify changes in a staging environment before they reach production, improving the overall deployment process.

AI: I've removed the summary heading and focused on describing the specific changes made to the workflow files.