### PR TITLE
ci: add optional comment on deploy

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -6,6 +6,10 @@ inputs:
   project_name:
     description: "The working directory/project name you're trying to deploy. Example: 'www', 'blog'"
     required: true
+  add_comment:
+    description: "Add a comment notification to the PR"
+    required: false
+    default: "false"
   NODE_ENV:
     description: "Vercel takes care of this"
     required: true
@@ -26,13 +30,17 @@ runs:
           cd apps/${{ inputs.project_name }} && \
           PREVIEW_URL=$(pnpm --filter @ashgw/${{ inputs.project_name }} deploy:vercel-preview --token=${{ inputs.VERCEL_TOKEN }} | grep -Eo 'https?://[^ ]+')
           echo "PREVIEW_URL=$PREVIEW_URL" >> $GITHUB_ENV
+          echo "::notice title=Preview URL::$PREVIEW_URL"
+          echo "preview-url=$PREVIEW_URL" >> $GITHUB_OUTPUT
         else
           cd apps/${{ inputs.project_name }} && \
-          pnpm --filter @ashgw/${{ inputs.project_name }} deploy:vercel-production --token=${{ inputs.VERCEL_TOKEN }}
+          PROD_URL=$(pnpm --filter @ashgw/${{ inputs.project_name }} deploy:vercel-production --token=${{ inputs.VERCEL_TOKEN }} | grep -Eo 'https?://[^ ]+')
+          echo "::notice title=Production URL::$PROD_URL"
+          echo "production-url=$PROD_URL" >> $GITHUB_OUTPUT
         fi
 
     - name: Notify mfs about the deployment URL
-      if: ${{ inputs.NODE_ENV == 'preview' }}
+      if: ${{ inputs.NODE_ENV == 'preview' }} && ${{ inputs.add_comment == 'true' }}
       uses: actions/github-script@v6
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -40,7 +40,7 @@ runs:
         fi
 
     - name: Notify mfs about the deployment URL
-      if: ${{ inputs.NODE_ENV == 'preview' }} && ${{ inputs.add_comment == 'true' }}
+      if: ${{ inputs.NODE_ENV == 'preview' && inputs.add_comment == 'true' }}
       uses: actions/github-script@v6
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-label-blog-preview.yml
+++ b/.github/workflows/on-pr-label-blog-preview.yml
@@ -14,4 +14,6 @@ jobs:
   blog-deploy-preview:
     if: github.event.label.name == 'deploy-preview'
     uses: ./.github/workflows/on-workflow-call-blog-preview-deployment.yml
+    with:
+      add_comment: true
     secrets: inherit

--- a/.github/workflows/on-pr-label-deploy-www-preview.yml
+++ b/.github/workflows/on-pr-label-deploy-www-preview.yml
@@ -14,4 +14,6 @@ jobs:
   www-deploy-preview:
     if: github.event.label.name == 'deploy-preview'
     uses: ./.github/workflows/on-workflow-call-www-preview-deployment.yml
+    with:
+      add_comment: true
     secrets: inherit

--- a/.github/workflows/on-workflow-call-blog-preview-deployment.yml
+++ b/.github/workflows/on-workflow-call-blog-preview-deployment.yml
@@ -2,6 +2,12 @@ name: CI / Blog preview deployment
 
 on:
   workflow_call:
+    inputs:
+      add_comment:
+        description: "Add a comment notification to the PR"
+        required: false
+        type: string
+        default: "false"
 
 permissions:
   pull-requests: write
@@ -35,6 +41,7 @@ jobs:
       - uses: ./.github/actions/vercel-deploy
         with:
           NODE_ENV: preview
+          add_comment: ${{ inputs.add_comment }}
           project_name: blog
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-workflow-call-www-preview-deployment.yml
+++ b/.github/workflows/on-workflow-call-www-preview-deployment.yml
@@ -2,6 +2,12 @@ name: CI / WWW preview deployment
 
 on:
   workflow_call:
+    inputs:
+      add_comment:
+        description: "Add a comment notification to the PR"
+        required: false
+        type: string
+        default: "false"
 
 permissions:
   pull-requests: write
@@ -35,6 +41,7 @@ jobs:
       - uses: ./.github/actions/vercel-deploy
         with:
           NODE_ENV: preview
+          add_comment: ${{ inputs.add_comment }}
           project_name: www
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Summary

This pull request introduces enhancements to the Vercel deployment action by adding an optional PR comment feature and improving URL handling in the project's CI/CD pipeline. The changes impact multiple files, including the Vercel deploy action configuration, workflow files for blog and www preview deployments, and workflow files for calling the deployment workflows.

The primary objective of these changes is to offer more flexibility in managing deployment notifications by enabling optional PR comments, reducing unnecessary noise in PRs, and enhancing the visibility of deployment URLs in workflow logs. Additionally, the updated workflow files now pass the `add_comment` parameter to the Vercel deploy action, facilitating easier access to deployment URLs for downstream workflow steps.

Specific modifications include updates to the Vercel deploy action configuration to incorporate the new `add_comment` input parameter, adjustments to workflow files to handle PR comments and deployment URLs, and enhancements to workflow logs with GitHub notice annotations for deployment URLs. The commit messages reflect the individual changes made, such as the addition of the optional comment feature and setting the parameter value to `true` for on label deployment.

Overall, these changes streamline deployment notification handling, improve workflow log visibility, and provide more customization options for deployment notifications within the project's CI/CD pipeline. The testing instructions ensure the functionality of PR comments, notice annotations, and URL outputs in various deployment scenarios.

### Files Changed
- `.github/actions/vercel-deploy/action.yml`
- `.github/workflows/on-pr-label-blog-preview.yml`
- `.github/workflows/on-pr-label-deploy-www-preview.yml`
- `.github/workflows/on-workflow-call-blog-preview-deployment.yml`
- `.github/workflows/on-workflow-call-www-preview-deployment.yml`

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>