### PR TITLE
ci: use base GH bot for changelog merges

### DIFF
--- a/.github/workflows/on-push-branch-main-update-changest.yml
+++ b/.github/workflows/on-push-branch-main-update-changest.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Commit and push changelog + bumps
         run: |
-          git config user.email "actions@github.com"
-          git config user.name "github-actions"
+          # git config user.email "actions@github.com" # looks ugly as hell dawg frfr
+          # git config user.name "github-actions"
           git add .
           git commit -m "chore: version bump via changesets [skip ci]" || echo "No changes to commit"
           git push origin main --follow-tags


### PR DESCRIPTION
## PR Summary

PR Title: Update CI workflow to use base GitHub bot for changelog merges

Files Changed: .github/workflows/on-push-branch-main-update-changest.yml

This pull request updates the CI workflow by utilizing the base GitHub bot for handling changelog merges. The change is reflected in the on-push-branch-main-update-changest.yml file. This modification streamlines the process of merging changelogs, improving automation and efficiency within the project's continuous integration pipeline.

### Files Changed
- `.github/workflows/on-push-branch-main-update-changest.yml`

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>