### PR TITLE
fix: add missing persmission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/on-workflow-call-update-changelog.yml
     secrets: inherit
+    permissions:
+      pull-requests: write
+      contents: write
 
   # just a trigger to dispatch
   preview-deployment:


### PR DESCRIPTION
## PR Summary

This pull request titled "fix: add missing permission" addresses a specific issue in the GitHub Actions workflow defined in .github/workflows/ci.yml. The purpose of this PR is to rectify a missing permission that prevented the workflow from writing to pull requests and repository contents. The code diff shows one change made in the ci.yml file to add the necessary permissions.

This change is crucial for ensuring that the changelog update workflow can function as intended by allowing it to interact with pull requests and repository contents. While the scope of this PR is limited to a single file, the impact is significant in enabling the workflow to perform its designated tasks effectively within the project's development and release processes.

### Files Changed
- `.github/workflows/ci.yml`

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>