### PR TITLE
ci: add `GH_PAT` instead of defualt action

### DIFF
--- a/.github/workflows/on-workflow-call-update-changelog.yml
+++ b/.github/workflows/on-workflow-call-update-changelog.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Create Pull Request for changelog update
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5
         with:
+          token: ${{ secrets.GH_PAT }}
           commit-message: "chore: changelog + version bump [skip ci]"
           branch: chore/changelog-update
           title: "chore: update changelog and version bump"


### PR DESCRIPTION
## PR Summary

PR Title: Update changelog workflow to use `GH_PAT` secret

Files Changed:

.github/workflows/on-workflow-call-update-changelog.yml

Commit Messages:

- ci: add `GH_PAT` instead of defualt action

This pull request updates the changelog workflow by replacing the default action with the use of the `GH_PAT` secret for authentication. This change ensures that the workflow has the necessary credentials to create pull requests. The modification is aimed at enhancing security and ensuring that sensitive information, such as authentication tokens, is properly managed within the workflow. The single change in the `.github/workflows/on-workflow-call-update-changelog.yml` file reflects this adjustment.

### Files Changed
- `.github/workflows/on-workflow-call-update-changelog.yml`

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>