### PR TITLE
chore: do not skip CI on version bumps

### DIFF
--- a/.github/workflows/on-pr-target-label-update-changelog.yml
+++ b/.github/workflows/on-pr-target-label-update-changelog.yml
@@ -43,5 +43,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md .
-          git commit -m "chore: changelog + version bump [skip ci]" || echo "Nothing to commit"
+          git commit -m "chore: changelog + version bump" || echo "Nothing to commit"
           git push origin HEAD:"${HEAD_REF}"


### PR DESCRIPTION
## PR Summary

**Chore**

Updates the CI workflow to ensure that it runs on version bump commits instead of being skipped. This change guarantees that all necessary checks are executed after updating the changelog and version information. No breaking changes, migration steps, or significant downstream effects are expected.

### Files Changed
- `.github/workflows/on-pr-target-label-update-changelog.yml` 📝 (modified)

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>