### PR TITLE
fix: update booking link

### DIFF
--- a/apps/www/src/middleware.ts
+++ b/apps/www/src/middleware.ts
@@ -1,8 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { BOOKING_LINK } from "@ashgw/constants";
-
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
 
@@ -15,9 +13,8 @@ export function middleware(request: NextRequest) {
   }
 
   if (pathname.startsWith("/booking")) {
-    const targetBaseUrl = BOOKING_LINK;
     const cleanPath = pathname.replace(/^\/booking/, "");
-    const targetUrl = `${targetBaseUrl}${cleanPath}${search}`;
+    const targetUrl = `https://cal.com/ashgw/default${cleanPath}${search}`;
     return NextResponse.redirect(targetUrl);
   }
 


### PR DESCRIPTION
## PR Summary

- In the file `apps/www/src/middleware.ts`, the booking redirect link was updated to point directly to `https://cal.com/ashgw/default` for all `/booking` routes.

- Two changes were detected in the `apps/www/src/middleware.ts` file during the update process.




<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>