### PR TITLE
fix: restore MDX seed files to 4b72bb78 version

### DIFF
--- a/packages/seeder/src/data/mdx/bounce-tracking.mdx
+++ b/packages/seeder/src/data/mdx/bounce-tracking.mdx
@@ -9,43 +9,20 @@ lastModDate: 2023-10-09T08:15:00-0401
 firstModDate: 2023-10-09T08:15:00-0401
 minutesToRead: 4
 tags:
-  - "http"
-  - "cybersec"
-  - "cookies"
+  - 'http'
+  - 'cybersec'
+  - 'cookies'
 ---
 
 <C>
-  Bounce tracking is a technique widely used by advertisers, marketers, and
-  analytics platforms to track user behavior across different websites and
-  gather detailed data on your online activity. This method involves redirecting
-  your request through one or more intermediary domains before you reach your
-  intended destination. Instead of going directly to a webpage, your request
-  might pass through a server, such as` ads-tracker.com`, where your data is
-  collected (all the time, without your consent). This could include your IP
-  address, browser type, operating system, cookies, session information, and
-  more.
+Bounce tracking is a technique widely used by advertisers, marketers, and analytics platforms to track user behavior across different websites and gather detailed data on your online activity. This method involves redirecting your request through one or more intermediary domains before you reach your intended destination. Instead of going directly to a webpage, your request might pass through a server, such as` ads-tracker.com`, where your data is collected (all the time, without your consent). This could include your IP address, browser type, operating system, cookies, session information, and more.
 </C>
 
 <C>
-  The main purpose of bounce tracking is to bypass restrictions on third-party
-  cookies. As modern web browsers become more privacy-conscious, they are
-  increasingly restricting the use of third-party cookies, which are going to be
-  dead by the end of 2024. Bounce tracking circumvents this by storing tracking
-  data in first-party cookies on the target websites. First-party cookies are
-  not subject to the same restrictions as third-party cookies which enables
-  advertisers and analytics platforms to continue monitoring user behavior and
-  linking actions across multiple domains, even when the user attempts to block
-  third-party tracking.
+The main purpose of bounce tracking is to bypass restrictions on third-party cookies. As modern web browsers become more privacy-conscious, they are increasingly restricting the use of third-party cookies, which are going to be dead by the end of 2024. Bounce tracking circumvents this by storing tracking data in first-party cookies on the target websites. First-party cookies are not subject to the same restrictions as third-party cookies which enables advertisers and analytics platforms to continue monitoring user behavior and linking actions across multiple domains, even when the user attempts to block third-party tracking.
 </C>
 <C>
-  This method offers significant benefits to marketers by providing them with
-  valuable insights into user behavior, but it raises serious concerns about
-  user privacy. Many users are unaware that their clicks are being silently
-  rerouted through intermediary tracking servers, without their knowledge or
-  consent. This effectively undermines privacy efforts, including using
-  privacy-focused browsers, VPNs, or extensions designed to block tracking. For
-  users who attempt to limit online surveillance, bounce tracking represents a
-  significant challenge because it works behind the scenes to evade detection.
+This method offers significant benefits to marketers by providing them with valuable insights into user behavior, but it raises serious concerns about user privacy. Many users are unaware that their clicks are being silently rerouted through intermediary tracking servers, without their knowledge or consent. This effectively undermines privacy efforts, including using privacy-focused browsers, VPNs, or extensions designed to block tracking. For users who attempt to limit online surveillance, bounce tracking represents a significant challenge because it works behind the scenes to evade detection.
 </C>
 
 <H2>

--- a/packages/seeder/src/data/mdx/branded-types.mdx
+++ b/packages/seeder/src/data/mdx/branded-types.mdx
@@ -28,13 +28,13 @@ tags:
 }
 
 type Foo = {
-id: string;
-foo: string;
+  id: string;
+  foo: string;
 };
 
 type Bar = {
-id: string;
-bar: string;
+  id: string;
+  bar: string;
 };
 
 const baz1 = requestBaz(foo.id, bar.id);
@@ -118,8 +118,8 @@ type BarID = NewType<'BarID', string>;`}
 };
 
 type Bar = {
-id: BarID;
-bar: string;
+  id: BarID;
+  bar: string;
 };`}
 language="tsx"
 showLineNumbers={false}
@@ -174,25 +174,25 @@ type FooID = NewType<'FooID', string>;
 type BarID = NewType<'BarID', string>;
 
 type Foo = {
-id: FooID;
-foo: string;
+  id: FooID;
+  foo: string;
 };
 
 type Bar = {
-id: BarID;
-bar: string;
+  id: BarID;
+  bar: string;
 };
 
 type Baz = NewType<'Baz', string>;
 
 function requestBaz(barID: BarID, fooID: FooID): Optional<Baz> {
 if (
-fooID.concat().toLowerCase() === 'fooid' &&
-barID.concat().toLowerCase() === 'barid'
+  fooID.concat().toLowerCase() === 'fooid' &&
+  barID.concat().toLowerCase() === 'barid'
 ) {
-return 'baz' as Baz;
+  return 'baz' as Baz;
 }
-return null; // Explicitly return null.
+  return null; // Explicitly return null.
 }
 
 const foo = {} as Foo;

--- a/packages/seeder/src/data/mdx/cholesterol.mdx
+++ b/packages/seeder/src/data/mdx/cholesterol.mdx
@@ -9,270 +9,143 @@ lastModDate: 2025-02-07T09:15:00-0401
 firstModDate: 2025-02-07T09:15:00-0401
 minutesToRead: 17
 tags:
-  - "cholesterol"
-  - "statins"
+  - 'cholesterol'
+  - 'statins'
   - "fat"
 ---
 
 <C>
-  I recently visited the doctor to update my insulin prescription, since insulin
-  purchases require a doctor's approval. During the visit, the doctor ordered a
-  **lipid panel**, which revealed the following results: - Total cholesterol:
-  3.78 g/L (approximately double the standard reference range) - HDL: 0.82 g/L -
-  LDL: 2.03 g/L (also considered HIGHLY elevated)
+I recently visited the doctor to update my insulin prescription, since insulin purchases require a doctor's approval. During the visit, the doctor ordered a **lipid panel**, which revealed the following results:
+- Total cholesterol: 3.78 g/L (approximately double the standard reference range)
+- HDL: 0.82 g/L 
+- LDL: 2.03 g/L (also considered HIGHLY elevated)
 </C>
 
 <C>
-  Based SOLELY on these numbers, the doctor prescribed **statins**, yes, statins
-  to a 23-year-old athlete in excellent physical condition. I declined the
-  prescription, took my insulin, and left.
+Based SOLELY on these numbers, the doctor prescribed **statins**, yes, statins to a 23-year-old athlete in excellent physical condition. I declined the prescription, took my insulin, and left.  
 </C>
 
 <C>
-  The doctor meant well, but modern medical education often omits the deeper
-  context I am about to explain here.
+The doctor meant well, but modern medical education often omits the deeper context I am about to explain here.
 </C>
 
 <C>
-  For background, I was diagnosed with **Type 1 Diabetes** about a year ago. I
-  immediately adopted a **carnivore diet**, and thanks to years of prior health
-  consciousness, I was able to stabilize my blood sugar levels within two weeks
-  from 300+ mg/dL to ~83 mg/dL, till this day, my fasting glucose levels are in
-  the 80s mg/dL.
+For background, I was diagnosed with **Type 1 Diabetes** about a year ago. I immediately adopted a **carnivore diet**, and thanks to years of prior health consciousness, I was able to stabilize my blood sugar levels within two weeks from 300+ mg/dL to ~83 mg/dL, till this day, my fasting glucose levels are in the 80s mg/dL.
 </C>
 
 <C>
-  Since then, whenever I mention my diet or progress, I often receive concerned
-  comments about **cholesterol levels**.
+Since then, whenever I mention my diet or progress, I often receive concerned comments about **cholesterol levels**.  
 </C>
 
 <C>
-  This article is intended to address those concerns properly, using both
-  historical and scientific context.
-</C>
-
-<C>The obsession with cholesterol has a long history.</C>
-
-<C>
-  In the mid-20th century, cardiovascular disease surged to become the leading
-  cause of mortality in America.
+This article is intended to address those concerns properly, using both historical and scientific context.
 </C>
 
 <C>
-  The medical establishment, desperate for an explanation, needed a scapegoat,
-  something tangible they could attribute to the epidemic, something simple
-  enough to package into public health campaigns.
-</C>
-
-<C>And so, they fixated on cholesterol and saturated fat.</C>
-
-<C>
-  At the heart of this movement was Ancel Keys, a physiologist whose work would
-  shape decades of dietary guidelines and public perception. In the 1950s, he
-  introduced the idea that dietary fat, saturated fat in particular was the
-  primary driver of heart disease. His Seven Countries Study purported to
-  demonstrate a strong correlation between saturated fat consumption and
-  cardiovascular disease. But the problem was that his data was deliberately
-  curated to fit his hypothesis. He initially collected data from 22 countries,
-  but when the correlation wasn’t strong enough, he conveniently excluded the
-  nations where high-fat diets were not associated with high rates of heart
-  disease. The final study only included the seven countries that **aligned with
-  his theory.** In other words, instead of letting the data guide his
-  conclusions, **he manipulated the data to reinforce his preconceived
-  beliefs.**
+The obsession with cholesterol has a long history.
 </C>
 
 <C>
-  Despite the methodological flaws, **his work gained traction.** In **1957,**
-  the American Heart Association (AHA) released a report suggesting that diet
-  played a significant role in heart disease, placing heavy emphasis on reducing
-  total fat intake. By 1961, the AHA doubled down, aggressively pushing
-  Americans to **slash saturated fat, lower cholesterol, and swap fats for
-  polyunsaturated vegetable oils**, a disastrous move that paved the way for
-  countless health issues. This was the first major institutional push toward
-  **low-fat, high-carb dietary policies**, and the impact of vegetable oils
-  alone is so massive that I might need a whole separate blog just to cover the
-  damage they’ve done.
+In the mid-20th century, cardiovascular disease surged to become the leading cause of mortality in America.
 </C>
 
 <C>
-  By the **1970s,** the push to demonize cholesterol reached its apex. In
-  **1977,** the U.S. Senate Select Committee on Nutrition and Human Needs, led
-  by **Senator George McGovern,** published the **Dietary Goals for the United
-  States.** This document formalized what had previously been just
-  recommendations, now, **it was official policy.
+The medical establishment, desperate for an explanation, needed a scapegoat, something tangible they could attribute to the epidemic, something simple enough to package into public health campaigns.
 </C>
 
 <C>
-  The guidelines urged Americans to reduce total fat intake from 40% to 30% of
-  total calories, limit saturated fat to no more than 10%, restrict cholesterol
-  intake, and increase carbohydrate consumption.
+And so, they fixated on cholesterol and saturated fat. 
 </C>
 
 <C>
-  And then, of course, came the studies that **"cemented" LDL cholesterol as the
-  enemy.** The **Brian Ference analysis** aggregated data from major cholesterol
-  studies and concluded that **higher LDL levels correlated with an increased
-  risk of atherosclerosis.** The **PESA trial** used advanced imaging technology
-  to show that **even LDL levels as low as 110 mg/dL** were associated with
-  arterial plaque formation. The **CARDIA study** tracked young men from age
-  **18** and found that those with the highest LDL levels developed
-  cardiovascular issues much earlier. The **JUPITER trial** showed that lowering
-  LDL through statins **reduced the risk of cardiovascular events,** and the
-  **Vietnam War veterans' autopsy study** found that young soldiers who died in
-  combat had significantly more arterial plaque **if they had higher cholesterol
-  levels.**
+At the heart of this movement was Ancel Keys, a physiologist whose work would shape decades of dietary guidelines and public perception. In the 1950s, he introduced the idea that dietary fat,  saturated fat in particular was the primary driver of heart disease. His Seven Countries Study purported to demonstrate a strong correlation between saturated fat consumption and cardiovascular disease. But the problem was that his data was deliberately curated to fit his hypothesis. He initially collected data from 22 countries, but when the correlation wasn’t strong enough, he conveniently excluded the nations where high-fat diets were not associated with high rates of heart disease. The final study only included the seven countries that **aligned with his theory.** In other words, instead of letting the data guide his conclusions, **he manipulated the data to reinforce his preconceived beliefs.**
 </C>
 
 <C>
-  But decades later, investigative reporting revealed internal documents showing
-  how **Big Sugar strategically funded research to shift the blame for heart
-  disease away from sugar and onto fat**. They knew that if fat was labeled as
-  the problem, sugar and refined carbohydrates would **fill the gap in the food
-  supply.** The industry wasn’t just passive in this shift, they actively
-  manipulated public perception. **They paid scientists, buried unfavorable
-  research, and guided policy decisions** that would make their products the
-  **default choice** for the American diet.
+Despite the methodological flaws, **his work gained traction.** In **1957,** the American Heart Association (AHA) released a report suggesting that diet played a significant role in heart disease, placing heavy emphasis on reducing total fat intake. By 1961, the AHA doubled down, aggressively pushing Americans to **slash saturated fat, lower cholesterol, and swap fats for polyunsaturated vegetable oils**, a disastrous move that paved the way for countless health issues. This was the first major institutional push toward **low-fat, high-carb dietary policies**, and the impact of vegetable oils alone is so massive that I might need a whole separate blog just to cover the damage they’ve done.
 </C>
 
 <C>
-  When McGovern’s committee released its dietary guidelines, they made an
-  audacious claim: **"Americans have nothing to lose by adopting a low-fat
-  diet."**. Although there were **no conclusive evidence** proving that reducing
-  dietary fat would prevent heart disease, the committee pushed the idea as if
-  it were **settled science.** regardless
+By the **1970s,** the push to demonize cholesterol reached its apex. In **1977,** the U.S. Senate Select Committee on Nutrition and Human Needs, led by **Senator George McGovern,** published the **Dietary Goals for the United States.** This document formalized what had previously been just recommendations, now, **it was official policy.
+</C>
+
+<C>
+The guidelines urged Americans to reduce total fat intake from 40% to 30% of total calories, limit saturated fat to no more than 10%, restrict cholesterol intake, and increase carbohydrate consumption.
+</C>
+
+<C>
+And then, of course, came the studies that **"cemented" LDL cholesterol as the enemy.** The **Brian Ference analysis** aggregated data from major cholesterol studies and concluded that **higher LDL levels correlated with an increased risk of atherosclerosis.** The **PESA trial** used advanced imaging technology to show that **even LDL levels as low as 110 mg/dL** were associated with arterial plaque formation. The **CARDIA study** tracked young men from age **18** and found that those with the highest LDL levels developed cardiovascular issues much earlier. The **JUPITER trial** showed that lowering LDL through statins **reduced the risk of cardiovascular events,** and the **Vietnam War veterans' autopsy study** found that young soldiers who died in combat had significantly more arterial plaque **if they had higher cholesterol levels.**
+</C>
+
+<C>
+But decades later, investigative reporting revealed internal documents showing how **Big Sugar strategically funded research to shift the blame for heart disease away from sugar and onto fat**.  They knew that if fat was labeled as the problem, sugar and refined carbohydrates would **fill the gap in the food supply.** The industry wasn’t just passive in this shift, they actively manipulated public perception. **They paid scientists, buried unfavorable research, and guided policy decisions** that would make their products the **default choice** for the American diet.
+</C>
+
+<C>
+When McGovern’s committee released its dietary guidelines, they made an audacious claim: **"Americans have nothing to lose by adopting a low-fat diet."**. Although there were **no conclusive evidence** proving that reducing dietary fat would prevent heart disease, the committee pushed the idea as if it were **settled science.** regardless
 </C>
 
 <C>
 
-The **USDA immediately followed suit,** formalizing these recommendations and reinforcing the idea that fats and oils should be eaten **“sparingly.”**. The public was told that fat was the root cause of heart disease, obesity, and metabolic disorders.
-
+The **USDA immediately followed suit,** formalizing these recommendations and reinforcing the idea that fats and oils should be eaten **“sparingly.”**. The public was told that fat was the root cause of heart disease, obesity, and metabolic disorders. 
 </C>
 
 <C>
-  By the 1980s, the **low-fat dogma had become deeply embedded in American
-  culture.** Grocery store shelves were flooded with **low-fat, high-carb
-  processed foods,** all marketed as “heart-healthy.” And the world followed
-  suit.
+By the 1980s, the **low-fat dogma had become deeply embedded in American culture.** Grocery store shelves were flooded with **low-fat, high-carb processed foods,** all marketed as “heart-healthy.” And the world followed suit.
 </C>
 
 <C>
-  The food industry **benefited immensely** from this shift. Fat, precisely
-  animal fat, is expensive to produce and difficult to store long-term.
-  Carbohydrates, on the other hand, are **cheap, highly profitable, and easy to
-  process, and very addictive.**
+The food industry **benefited immensely** from this shift. Fat, precisely animal fat, is expensive to produce and difficult to store long-term. Carbohydrates, on the other hand, are **cheap, highly profitable, and easy to process, and very addictive.** 
 </C>
 
 <C>
-  By demonizing saturated fat and promoting grain-based foods, the agricultural
-  and processed food industries found themselves in an **unparalleled position
-  of economic advantage, they were printing.**
+By demonizing saturated fat and promoting grain-based foods, the agricultural and processed food industries found themselves in an **unparalleled position of economic advantage, they were printing.** 
 </C>
 
 <C>
-  The pharma industry also stood to gain, as this diet shift lead to a surge in
-  chronic illness, thus the need for medication.
-</C>
-
-<C>But cracks in the narrative were forming.</C>
-
-<C>
-  For decades, cholesterol has been scapegoated as the primary driver of heart
-  disease, but this narrative crumbles under closer examination, all of the
-  "research" against cholesterol, has been debunked. The problem isn’t the data
-  itself but it's in the way that data has been selectively interpreted. The
-  mainstream cholesterol hypothesis is fundamentally flawed, reducing heart
-  disease risk to a single biomarker while ignoring the far more important
-  influences of metabolic health. LDL alone is not the cause of heart disease,
-  its role is entirely dependent on context.
+The pharma industry also stood to gain, as this diet shift lead to a surge in chronic illness, thus the need for medication.
 </C>
 
 <C>
-  The anti-cholesterol movement was never built on a true understanding of human
-  metabolism. Instead, it cherry-picked findings, ignored contradictions, and
-  dismissed the complex role of dietary fats. Compelling, irrefutable evidence
-  contradicting the LDL-centric model has existed for decades. Landmark studies,
-  starting as early as the 1950s, challenged the simplistic link between
-  cholesterol and heart disease, yet they were misinterpreted, downplayed, or
-  outright ignored. Research such as the Framingham Heart Study, the Honolulu
-  Heart Program, and later large-scale analyses exposed glaring inconsistencies
-  in the cholesterol hypothesis. These studies at the time revealed that total
-  cholesterol and LDL cholesterol levels alone fail to predict cardiovascular
-  risk in many populations, especially when other metabolic factors are
-  considered.
+But cracks in the narrative were forming.
 </C>
 
 <C>
-  Doctors and researchers who refused to fall in line started **challenging the
-  low-fat paradigm.** One of the most vocal figures was **Dr. Robert Atkins.**
-  He argued that the **real culprits of obesity and metabolic disease weren’t
-  fats, but processed carbohydrates.** Atkins promoted a **high-fat, low-carb
-  diet,** directly opposing the establishment’s guidelines. He pointed out that
-  **as fat intake declined, obesity and diabetes rates skyrocketed.** The rise
-  of refined carbohydrate consumption, fueled by low-fat dietary
-  recommendations, **correlated almost perfectly with the obesity epidemic of
-  the 80s and the 90s.**
+For decades, cholesterol has been scapegoated as the primary driver of heart disease, but this narrative crumbles under closer examination, all of the "research" against cholesterol, has been debunked. The problem isn’t the data itself but it's in the way that data has been selectively interpreted. The mainstream cholesterol hypothesis is fundamentally flawed, reducing heart disease risk to a single biomarker while ignoring the far more important influences of metabolic health. LDL alone is not the cause of heart disease, its role is entirely dependent on context.
 </C>
 
 <C>
-  And yet, **mainstream nutrition science refused to engage.** Instead of
-  reassessing their approach, they **attacked** anyone who questioned them.
-  Atkins, and others like him, were labeled **pseudoscientists, extremists, or
-  quacks.**
+The anti-cholesterol movement was never built on a true understanding of human metabolism. Instead, it cherry-picked findings, ignored contradictions, and dismissed the complex role of dietary fats. Compelling, irrefutable evidence contradicting the LDL-centric model has existed for decades. Landmark studies, starting as early as the 1950s, challenged the simplistic link between cholesterol and heart disease, yet they were misinterpreted, downplayed, or outright ignored. Research such as the Framingham Heart Study, the Honolulu Heart Program, and later large-scale analyses exposed glaring inconsistencies in the cholesterol hypothesis. These studies at the time revealed that total cholesterol and LDL cholesterol levels alone fail to predict cardiovascular risk in many populations, especially when other metabolic factors are considered.
 </C>
 
 <C>
-  By the early 1990s, studies were showing that **low-fat diets weren’t solving
-  anything, and one of the most crucial realizations from recent research is
-  that cholesterol is not inherently harmful.
+Doctors and researchers who refused to fall in line started **challenging the low-fat paradigm.** One of the most vocal figures was **Dr. Robert Atkins.** He argued that the **real culprits of obesity and metabolic disease weren’t fats, but processed carbohydrates.** Atkins promoted a **high-fat, low-carb diet,** directly opposing the establishment’s guidelines. He pointed out that **as fat intake declined, obesity and diabetes rates skyrocketed.** The rise of refined carbohydrate consumption, fueled by low-fat dietary recommendations, **correlated almost perfectly with the obesity epidemic of the 80s and the 90s.**
 </C>
 
 <C>
-  Cholesterol is an essential molecule required for various bodily functions,
-  including the production of hormones, vitamin D synthesis, and cell membrane
-  integrity. The body itself produces cholesterol because it is so vital to
-  survival. The conventional focus on total cholesterol levels as a primary
-  indicator of heart disease risk fails to take into account the complexity of
-  cholesterol metabolism and the many factors that influence cardiovascular
-  health.
+And yet, **mainstream nutrition science refused to engage.** Instead of reassessing their approach, they **attacked** anyone who questioned them. Atkins, and others like him, were labeled **pseudoscientists, extremists, or quacks.**
 </C>
 
 <C>
-  The standard narrative often emphasizes that low-density lipoprotein (LDL),
-  commonly labeled as “bad” cholesterol, is the primary driver of heart disease.
-  The notion that all LDL is inherently dangerous is misleading. LDL is not a
-  single uniform entity; rather, it comes in different particle sizes. Small,
-  dense LDL particles are much more atherogenic than large, buoyant LDL
-  particles because they are more susceptible to oxidation and more likely to
-  penetrate arterial walls, contributing to plaque formation. Large LDL
-  particles, on the other hand, are far less harmful. A study published in the
-  American Journal of Clinical Nutrition (2010) found that individuals with a
-  high proportion of small, dense LDL had a significantly increased risk of
-  heart disease, whereas those with predominantly large LDL particles did not.
+By the early 1990s, studies were showing that **low-fat diets weren’t solving anything, and one of the most crucial realizations from recent research is that cholesterol is not inherently harmful. 
 </C>
 
 <C>
-  A pivotal study published in the Journal of the American College of Cardiology
-  in 2005 confirmed that LDL particle size is a much stronger predictor of heart
-  disease than total LDL levels. Individuals with high levels of small, dense
-  LDL were found to be three times more likely to develop coronary artery
-  disease than those with high levels of large, buoyant LDL. Similarly, a 2014
-  meta-analysis in the Annals of Internal Medicine, which reviewed data from
-  over 600,000 individuals, found no significant association between dietary
-  saturated fat intake and heart disease risk. This contradicts the long-held
-  belief that saturated fat raises cholesterol and, by extension, increases
-  cardiovascular risk.
+Cholesterol is an essential molecule required for various bodily functions, including the production of hormones, vitamin D synthesis, and cell membrane integrity. The body itself produces cholesterol because it is so vital to survival. The conventional focus on total cholesterol levels as a primary indicator of heart disease risk fails to take into account the complexity of cholesterol metabolism and the many factors that influence cardiovascular health.
 </C>
 
 <C>
-  Another critical aspect of cholesterol metabolism that is often ignored is the
-  role of high-density lipoprotein (HDL), or “good” cholesterol as your doctor
-  calls it. HDL helps remove excess cholesterol from the bloodstream and
-  transports it to the liver for processing and elimination. Higher levels of
-  HDL are associated with a reduced risk of heart disease, and the ratio of
-  triglycerides to HDL is often a far better predictor of cardiovascular risk
-  than LDL alone:
+The standard narrative often emphasizes that low-density lipoprotein (LDL), commonly labeled as “bad” cholesterol, is the primary driver of heart disease.  The notion that all LDL is inherently dangerous is misleading. LDL is not a single uniform entity; rather, it comes in different particle sizes. Small, dense LDL particles are much more atherogenic than large, buoyant LDL particles because they are more susceptible to oxidation and more likely to penetrate arterial walls, contributing to plaque formation. Large LDL particles, on the other hand, are far less harmful. A study published in the American Journal of Clinical Nutrition (2010) found that individuals with a high proportion of small, dense LDL had a significantly increased risk of heart disease, whereas those with predominantly large LDL particles did not.
 </C>
+
+<C>
+A pivotal study published in the Journal of the American College of Cardiology in 2005 confirmed that LDL particle size is a much stronger predictor of heart disease than total LDL levels. Individuals with high levels of small, dense LDL were found to be three times more likely to develop coronary artery disease than those with high levels of large, buoyant LDL. Similarly, a 2014 meta-analysis in the Annals of Internal Medicine, which reviewed data from over 600,000 individuals, found no significant association between dietary saturated fat intake and heart disease risk. This contradicts the long-held belief that saturated fat raises cholesterol and, by extension, increases cardiovascular risk.
+</C>
+
+<C>
+Another critical aspect of cholesterol metabolism that is often ignored is the role of high-density lipoprotein (HDL), or “good” cholesterol as your doctor calls it. HDL helps remove excess cholesterol from the bloodstream and transports it to the liver for processing and elimination. Higher levels of HDL are associated with a reduced risk of heart disease, and the ratio of triglycerides to HDL is often a far better predictor of cardiovascular risk than LDL alone: 
+</C>
+
 
 <C>
 The triglycerides to HDL ratio is calculated as:
@@ -287,251 +160,86 @@ The triglycerides to HDL ratio is calculated as:
 </C>
 
 <C>
-  A study published in Circulation in 2008 demonstrated that individuals with a
-  high triglyceride-to-HDL ratio had a significantly increased risk of heart
-  disease, even when LDL levels were within the so-called “normal” range.
+A study published in Circulation in 2008 demonstrated that individuals with a high triglyceride-to-HDL ratio had a significantly increased risk of heart disease, even when LDL levels were within the so-called “normal” range. 
 </C>
 
 <C>
-  One of the most revealing pieces of evidence challenging the cholesterol
-  hypothesis is the repeated failure of cholesterol-lowering drugs to
-  significantly reduce heart disease risk in populations with normal cholesterol
-  levels. While statins are widely prescribed to lower LDL cholesterol, their
-  effectiveness is increasingly being questioned. Numerous studies have
-  demonstrated that the purported benefits of statins are often exaggerated and
-  that their actual impact on heart disease prevention is limited. A
-  comprehensive review published in the journal Expert Review of Clinical
-  Pharmacology found that there is no consistent correlation between LDL
-  cholesterol reduction and reduced cardiovascular risk, thus undermining the
-  core premise behind statin therapy. Another study published in the BMJ
-  Evidence-Based Medicine journal outlined how statistical manipulation has
-  contributed to the illusion that statins are more effective than they truly
-  are.
+One of the most revealing pieces of evidence challenging the cholesterol hypothesis is the repeated failure of cholesterol-lowering drugs to significantly reduce heart disease risk in populations with normal cholesterol levels. While statins are widely prescribed to lower LDL cholesterol, their effectiveness is increasingly being questioned. Numerous studies have demonstrated that the purported benefits of statins are often exaggerated and that their actual impact on heart disease prevention is limited. A comprehensive review published in the journal Expert Review of Clinical Pharmacology found that there is no consistent correlation between LDL cholesterol reduction and reduced cardiovascular risk, thus undermining the core premise behind statin therapy. Another study published in the BMJ Evidence-Based Medicine journal outlined how statistical manipulation has contributed to the illusion that statins are more effective than they truly are.
 </C>
 
 <C>
-  The JUPITER trial, published in the New England Journal of Medicine in 2008,
-  found that individuals with elevated CRP levels, a marker of inflammation,
-  benefited from statin therapy even when their LDL cholesterol levels were not
-  particularly high. However, critics argue that this does not validate statins
-  as a universal treatment, but rather underscores the role of inflammation in
-  cardiovascular disease. The reality is that for individuals with no prior
-  history of heart disease, statin therapy offers minimal to no mortality
-  benefit. Studies such as those published in Semantics Scholar and the American
-  Journal of Medicine have suggested that in many cases, the risks of statins,
-  including muscle damage, cognitive impairment, and increased risk of diabetes,
-  outweigh their benefits.
+The JUPITER trial, published in the New England Journal of Medicine in 2008, found that individuals with elevated CRP levels, a marker of inflammation, benefited from statin therapy even when their LDL cholesterol levels were not particularly high. However, critics argue that this does not validate statins as a universal treatment, but rather underscores the role of inflammation in cardiovascular disease. The reality is that for individuals with no prior history of heart disease, statin therapy offers minimal to no mortality benefit. Studies such as those published in Semantics Scholar and the American Journal of Medicine have suggested that in many cases, the risks of statins, including muscle damage, cognitive impairment, and increased risk of diabetes, outweigh their benefits.
 </C>
 
 <C>
-  Furthermore, research has shown that elderly populations with higher
-  cholesterol levels tend to have lower all-cause mortality rates, further
-  challenging the necessity of statin therapy for primary prevention. A study
-  published in PubMed (2022) concluded that cholesterol-lowering interventions
-  do not significantly improve lifespan in individuals over the age of 65.
-  Additionally, a paper in the Scandinavian Cardiovascular Journal argues that
-  the aggressive push for statin prescriptions is largely driven by
-  pharmaceutical interests rather than strong clinical evidence. This suggests
-  that the real focus should be on reducing inflammation and metabolic
-  dysfunction rather than simply lowering cholesterol with drugs that provide
-  minimal tangible benefit.
+Furthermore, research has shown that elderly populations with higher cholesterol levels tend to have lower all-cause mortality rates, further challenging the necessity of statin therapy for primary prevention. A study published in PubMed (2022) concluded that cholesterol-lowering interventions do not significantly improve lifespan in individuals over the age of 65. Additionally, a paper in the Scandinavian Cardiovascular Journal argues that the aggressive push for statin prescriptions is largely driven by pharmaceutical interests rather than strong clinical evidence. This suggests that the real focus should be on reducing inflammation and metabolic dysfunction rather than simply lowering cholesterol with drugs that provide minimal tangible benefit.
 </C>
 
 <C>
-  Moreover, the risks associated with excessively lowering cholesterol levels
-  are often underappreciated. Extremely low cholesterol levels have been linked
-  to an increased risk of neurodegenerative diseases, cognitive decline, and
-  even higher mortality rates in some studies. Cholesterol is critical for brain
-  function, and the literature shows that individuals with very low cholesterol
-  levels may be at a greater risk for conditions such as Alzheimer’s disease.
-  Furthermore, a study published in BMJ in 2016 found that among elderly
-  populations, higher cholesterol levels were associated with lower overall
-  mortality, challenging the assumption that lowering cholesterol is always
-  beneficial.
+Moreover, the risks associated with excessively lowering cholesterol levels are often underappreciated. Extremely low cholesterol levels have been linked to an increased risk of neurodegenerative diseases, cognitive decline, and even higher mortality rates in some studies. Cholesterol is critical for brain function, and the literature shows that individuals with very low cholesterol levels may be at a greater risk for conditions such as Alzheimer’s disease. Furthermore, a study published in BMJ in 2016 found that among elderly populations, higher cholesterol levels were associated with lower overall mortality, challenging the assumption that lowering cholesterol is always beneficial.
 </C>
 
 <C>
-  Creating a more accurate assessment of cardiovascular risk requires looking
-  beyond LDL cholesterol levels, which offer only a partial and often misleading
-  picture of heart health. The human body operates through an intricate web of
-  metabolic, inflammatory, and vascular processes, all of which contribute to
-  cardiovascular disease in ways that cholesterol alone cannot fully explain. A
-  more comprehensive approach considers various biomarkers that provide insight
-  into the mechanisms driving atherosclerosis, inflammation, and metabolic
-  dysfunction.
+Creating a more accurate assessment of cardiovascular risk requires looking beyond LDL cholesterol levels, which offer only a partial and often misleading picture of heart health. The human body operates through an intricate web of metabolic, inflammatory, and vascular processes, all of which contribute to cardiovascular disease in ways that cholesterol alone cannot fully explain. A more comprehensive approach considers various biomarkers that provide insight into the mechanisms driving atherosclerosis, inflammation, and metabolic dysfunction.
 </C>
 
 <C>
-  One of the most critical factors in cardiovascular risk is glucose metabolism.
-  Hemoglobin A1c, or HbA1c, reflects the average blood sugar levels over the
-  past two to three months, making it a key indicator of long-term glucose
-  control. Chronically elevated blood glucose leads to glycation, a process
-  where sugar molecules attach to proteins and fats, causing oxidative stress
-  and inflammation that damage blood vessels over time. This damage contributes
-  to endothelial dysfunction, a precursor to atherosclerosis, where arteries
-  lose their ability to dilate properly and accumulate plaques more readily.
-  Even in individuals without overt diabetes, higher HbA1c levels are associated
-  with increased cardiovascular risk, as they indicate underlying insulin
-  resistance, a state in which the body's cells become less responsive to
-  insulin, forcing the pancreas to produce more of it. Insulin resistance itself
-  promotes a pro-inflammatory environment, accelerates lipid oxidation, and
-  leads to arterial plaque development. Fasting glucose levels, while providing
-  a snapshot rather than a long-term average, serve as a complementary measure
-  by revealing how efficiently the body manages blood sugar levels in a baseline
-  state. Chronic elevations in fasting glucose suggest that insulin resistance
-  has progressed to the point where the body can no longer keep glucose levels
-  in check, setting the stage for both diabetes and cardiovascular disease.
+One of the most critical factors in cardiovascular risk is glucose metabolism. Hemoglobin A1c, or HbA1c, reflects the average blood sugar levels over the past two to three months, making it a key indicator of long-term glucose control. Chronically elevated blood glucose leads to glycation, a process where sugar molecules attach to proteins and fats, causing oxidative stress and inflammation that damage blood vessels over time. This damage contributes to endothelial dysfunction, a precursor to atherosclerosis, where arteries lose their ability to dilate properly and accumulate plaques more readily. Even in individuals without overt diabetes, higher HbA1c levels are associated with increased cardiovascular risk, as they indicate underlying insulin resistance, a state in which the body's cells become less responsive to insulin, forcing the pancreas to produce more of it. Insulin resistance itself promotes a pro-inflammatory environment, accelerates lipid oxidation, and leads to arterial plaque development. Fasting glucose levels, while providing a snapshot rather than a long-term average, serve as a complementary measure by revealing how efficiently the body manages blood sugar levels in a baseline state. Chronic elevations in fasting glucose suggest that insulin resistance has progressed to the point where the body can no longer keep glucose levels in check, setting the stage for both diabetes and cardiovascular disease.
 </C>
 
 <C>
-  Inflammation is another key driver of heart disease, and C-reactive protein
-  (CRP) serves as one of the most reliable indicators of systemic inflammation.
-  Produced by the liver in response to inflammatory signals, CRP is a marker of
-  the body’s immune response to injury, infection, or chronic stress. When
-  inflammation becomes chronic, as seen in metabolic syndrome, obesity, and
-  insulin resistance, CRP levels remain elevated, signaling persistent vascular
-  irritation. This continuous state of low-grade inflammation weakens arterial
-  walls and makes them more susceptible to plaque formation and rupture. The
-  role of inflammation in cardiovascular disease extends beyond lipid levels, as
-  even individuals with normal cholesterol can suffer heart attacks if chronic
-  inflammation destabilizes arterial plaques, leading to thrombosis and sudden
-  vessel blockage.
+Inflammation is another key driver of heart disease, and C-reactive protein (CRP) serves as one of the most reliable indicators of systemic inflammation. Produced by the liver in response to inflammatory signals, CRP is a marker of the body’s immune response to injury, infection, or chronic stress. When inflammation becomes chronic, as seen in metabolic syndrome, obesity, and insulin resistance, CRP levels remain elevated, signaling persistent vascular irritation. This continuous state of low-grade inflammation weakens arterial walls and makes them more susceptible to plaque formation and rupture. The role of inflammation in cardiovascular disease extends beyond lipid levels, as even individuals with normal cholesterol can suffer heart attacks if chronic inflammation destabilizes arterial plaques, leading to thrombosis and sudden vessel blockage.
 </C>
 
 <C>
-  A far more direct measurement of cardiovascular disease is the Coronary Artery
-  Calcium (CAC) score, which quantifies calcified plaque buildup in the
-  arteries. The CAC score provides concrete evidence of existing
-  atherosclerosis. Unlike blood lipid levels, which fluctuate based on diet and
-  medication, arterial calcification represents a cumulative history of vascular
-  damage and the body's attempts to stabilize arterial plaques by depositing
-  calcium. The presence of calcification signifies a more advanced stage of
-  cardiovascular disease, indicating a higher likelihood of heart attacks and
-  strokes, even in individuals who might otherwise appear low-risk based on
-  standard lipid panel testing.
+A far more direct measurement of cardiovascular disease is the Coronary Artery Calcium (CAC) score, which quantifies calcified plaque buildup in the arteries. The CAC score provides concrete evidence of existing atherosclerosis. Unlike blood lipid levels, which fluctuate based on diet and medication, arterial calcification represents a cumulative history of vascular damage and the body's attempts to stabilize arterial plaques by depositing calcium. The presence of calcification signifies a more advanced stage of cardiovascular disease, indicating a higher likelihood of heart attacks and strokes, even in individuals who might otherwise appear low-risk based on standard lipid panel testing.
 </C>
 
 <C>
-  Blood clotting dynamics also play a major role in cardiovascular risk, and
-  fibrinogen is one of the primary proteins responsible for clot formation.
-  Elevated fibrinogen levels increase blood viscosity and promote
-  hypercoagulability, meaning the blood is more prone to forming clots. This
-  state significantly raises the risk of thrombosis, where clots form inside
-  blood vessels and can lead to heart attacks or strokes. Chronic inflammation,
-  oxidative stress, and metabolic dysfunction all contribute to higher
-  fibrinogen levels, making it an important marker for assessing not only
-  clotting risk but also underlying inflammatory processes that drive
-  cardiovascular disease.
+Blood clotting dynamics also play a major role in cardiovascular risk, and fibrinogen is one of the primary proteins responsible for clot formation. Elevated fibrinogen levels increase blood viscosity and promote hypercoagulability, meaning the blood is more prone to forming clots. This state significantly raises the risk of thrombosis, where clots form inside blood vessels and can lead to heart attacks or strokes. Chronic inflammation, oxidative stress, and metabolic dysfunction all contribute to higher fibrinogen levels, making it an important marker for assessing not only clotting risk but also underlying inflammatory processes that drive cardiovascular disease.
 </C>
 
 <C>
-  Lipoproteins themselves are not all created equal, and oxidized LDL (oxLDL) is
-  a dangerous form of cholesterol particle that significantly accelerates
-  atherosclerosis. Unlike regular LDL, which transports cholesterol through the
-  bloodstream, oxLDL is LDL that has undergone oxidative modification due to
-  exposure to free radicals. This oxidative process makes LDL far more reactive
-  and inflammatory, leading to its rapid uptake by macrophages, the immune cells
-  that engulf oxidized lipids to form foam cells, the building blocks of
-  arterial plaques. The more oxLDL present in circulation, the greater the
-  likelihood of aggressive plaque formation and instability, making it a far
-  more useful predictor of cardiovascular risk than total LDL cholesterol alone.
+Lipoproteins themselves are not all created equal, and oxidized LDL (oxLDL) is a dangerous form of cholesterol particle that significantly accelerates atherosclerosis. Unlike regular LDL, which transports cholesterol through the bloodstream, oxLDL is LDL that has undergone oxidative modification due to exposure to free radicals. This oxidative process makes LDL far more reactive and inflammatory, leading to its rapid uptake by macrophages, the immune cells that engulf oxidized lipids to form foam cells, the building blocks of arterial plaques. The more oxLDL present in circulation, the greater the likelihood of aggressive plaque formation and instability, making it a far more useful predictor of cardiovascular risk than total LDL cholesterol alone.
 </C>
 
 <C>
-  Another contributor to cardiovascular disease is homocysteine, an amino acid
-  involved in the methylation cycle, which regulates various biochemical
-  reactions in the body, including DNA repair and neurotransmitter synthesis.
-  Elevated homocysteine levels are associated with endothelial dysfunction, as
-  excess homocysteine damages the delicate inner lining of blood vessels,
-  increasing their susceptibility to inflammation and plaque accumulation. High
-  homocysteine levels have also been linked to increased oxidative stress, which
-  further amplifies vascular damage and raises the risk of clot formation.
+Another contributor to cardiovascular disease is homocysteine, an amino acid involved in the methylation cycle, which regulates various biochemical reactions in the body, including DNA repair and neurotransmitter synthesis. Elevated homocysteine levels are associated with endothelial dysfunction, as excess homocysteine damages the delicate inner lining of blood vessels, increasing their susceptibility to inflammation and plaque accumulation. High homocysteine levels have also been linked to increased oxidative stress, which further amplifies vascular damage and raises the risk of clot formation.
 </C>
 
 <C>
-  Apolipoprotein B (ApoB) offers a more precise measurement of atherogenic
-  lipoproteins in circulation than LDL cholesterol alone. Each atherogenic
-  particle, including LDL, very-low-density lipoproteins (VLDL), and
-  intermediate-density lipoproteins (IDL), contains one ApoB molecule. This
-  means that ApoB directly quantifies the total number of particles capable of
-  penetrating arterial walls and contributing to plaque buildup. Unlike LDL
-  cholesterol concentration, which measures the mass of cholesterol within these
-  particles, ApoB provides a clearer picture of how many cholesterol-carrying
-  particles are actually present. Since small, dense LDL particles are more
-  atherogenic than large, fluffy LDL particles, measuring ApoB eliminates the
-  uncertainty that comes with standard LDL testing, making it a superior marker
-  of cardiovascular risk.
+Apolipoprotein B (ApoB) offers a more precise measurement of atherogenic lipoproteins in circulation than LDL cholesterol alone. Each atherogenic particle, including LDL, very-low-density lipoproteins (VLDL), and intermediate-density lipoproteins (IDL), contains one ApoB molecule. This means that ApoB directly quantifies the total number of particles capable of penetrating arterial walls and contributing to plaque buildup. Unlike LDL cholesterol concentration, which measures the mass of cholesterol within these particles, ApoB provides a clearer picture of how many cholesterol-carrying particles are actually present. Since small, dense LDL particles are more atherogenic than large, fluffy LDL particles, measuring ApoB eliminates the uncertainty that comes with standard LDL testing, making it a superior marker of cardiovascular risk.
 </C>
 
 <C>
-  Lipoprotein(a), or Lp(a), is a genetically determined lipoprotein variant that
-  is structurally similar to LDL but includes an additional protein called
-  apolipoprotein(a). Lp(a) is dangerous because it not only contributes to
-  cholesterol transport but also promotes thrombosis by interfering with
-  fibrinolysis, the body's ability to break down clots. This dual role makes
-  Lp(a) an independent risk factor for heart attacks and strokes, regardless of
-  other lipid parameters. Since Lp(a) levels are largely unaffected by lifestyle
-  or diet and are determined almost entirely by genetics, individuals with high
-  Lp(a) often remain unaware of their elevated cardiovascular risk until an
-  event occurs. Standard lipid panels do not typically measure Lp(a), meaning
-  many people with dangerously high levels go undiagnosed.
+Lipoprotein(a), or Lp(a), is a genetically determined lipoprotein variant that is structurally similar to LDL but includes an additional protein called apolipoprotein(a). Lp(a) is dangerous because it not only contributes to cholesterol transport but also promotes thrombosis by interfering with fibrinolysis, the body's ability to break down clots. This dual role makes Lp(a) an independent risk factor for heart attacks and strokes, regardless of other lipid parameters. Since Lp(a) levels are largely unaffected by lifestyle or diet and are determined almost entirely by genetics, individuals with high Lp(a) often remain unaware of their elevated cardiovascular risk until an event occurs. Standard lipid panels do not typically measure Lp(a), meaning many people with dangerously high levels go undiagnosed. 
 </C>
 
 <C>
-  Compounding this risk, **Lipoprotein-Associated Phospholipase A2 (Lp-PLA2)**
-  is another inflammatory marker linked to cardiovascular disease. Lp-PLA2 is an
-  enzyme that **breaks down oxidized LDL particles**, leading to the production
-  of inflammatory byproducts that contribute to arterial wall damage. High
-  Lp-PLA2 levels indicate an **increased likelihood of developing unstable,
-  rupture-prone plaques** that can trigger strokes and heart attacks. Unlike
-  general inflammation markers like CRP, Lp-PLA2 specifically reflects
-  **vascular inflammation**.
+Compounding this risk,  **Lipoprotein-Associated Phospholipase A2 (Lp-PLA2)** is another inflammatory marker linked to cardiovascular disease. Lp-PLA2 is an enzyme that **breaks down oxidized LDL particles**, leading to the production of inflammatory byproducts that contribute to arterial wall damage. High Lp-PLA2 levels indicate an **increased likelihood of developing unstable, rupture-prone plaques** that can trigger strokes and heart attacks. Unlike general inflammation markers like CRP, Lp-PLA2 specifically reflects **vascular inflammation**.
 </C>
 
 <C>
-  You can also measure **F2-Isoprostanes**, **Myeloperoxidase (MPO)**, **B-type
-  Natriuretic Peptide (BNP)**, **ADMA/SDMA**, and the list goes on and on, I can
-  keep going.
+You can also measure **F2-Isoprostanes**, **Myeloperoxidase (MPO)**, **B-type Natriuretic Peptide (BNP)**, **ADMA/SDMA**, and the list goes on and on, I can keep going. 
 </C>
 
 <C>
-  The point is, that modern diagnostics capture the complexity of cardiovascular
-  health far beyond the simplistic LDL cholesterol metric. The interplay of
-  these markers paints a much more detailed and accurate picture of
-  cardiovascular well-being. Our cardiovascular system is not governed solely by
-  lipid transport; it is the result of a complex interaction between metabolic
-  efficiency, inflammation, oxidative stress, coagulation balance, and vascular
-  integrity. Evaluating these diverse factors together allows for a far more
-  precise assessment of risk, offering actionable insights into prevention and
-  treatment. But relying solely on LDL cholesterol as the primary determinant of
-  heart health is not only outdated but also dangerously misleading. This narrow
-  focus fails to capture the underlying processes that truly drive heart
-  disease.
+The point is, that modern diagnostics capture the complexity of cardiovascular health far beyond the simplistic LDL cholesterol metric. The interplay of these markers paints a much more detailed and accurate picture of cardiovascular well-being. Our cardiovascular system is not governed solely by lipid transport; it is the result of a complex interaction between metabolic efficiency, inflammation, oxidative stress, coagulation balance, and vascular integrity. Evaluating these diverse factors together allows for a far more precise assessment of risk, offering actionable insights into prevention and treatment. But relying solely on LDL cholesterol as the primary determinant of heart health is not only outdated but also dangerously misleading. This narrow focus fails to capture the underlying processes that truly drive heart disease.
 </C>
 
 <C>
-  The consequences of this decades-long deception are **immeasurable.**
-  Generations were led to believe that fat was dangerous, that cholesterol was
-  something to fear, and that the key to good health was found in a diet filled
-  with **processed grains, sugar, and seed oils.** Today, we are still living
-  with the fallout: **obesity rates are at an all-time high, diabetes continues
-  its relentless rise, and heart disease remains the number one killer.**
+The consequences of this decades-long deception are **immeasurable.** Generations were led to believe that fat was dangerous, that cholesterol was something to fear, and that the key to good health was found in a diet filled with **processed grains, sugar, and seed oils.** Today, we are still living with the fallout: **obesity rates are at an all-time high, diabetes continues its relentless rise, and heart disease remains the number one killer.**
 </C>
 
 <C>
-  Yet, despite mounting evidence and clinical breakthroughs, the same **failed
-  dietary principles** continue to be taught, enforced, and promoted as the
-  standard for health. The narrative has kept many locked into a cycle of poor
-  health choices, all while promising salvation through outdated guidelines that
-  simply do not work.
+Yet, despite mounting evidence and clinical breakthroughs, the same **failed dietary principles** continue to be taught, enforced, and promoted as the standard for health. The narrative has kept many locked into a cycle of poor health choices, all while promising salvation through outdated guidelines that simply do not work.
 </C>
 
 <C>
-  No one is coming to save you, it is up to you to take control of your own
-  health. If I had followed the mainstream advice on managing my type 1
-  diabetes, I would have been trapped in a cycle of blood sugar spikes, insulin
-  dependence, and declining well-being. Instead, I chose to think for myself,
-  challenge the narrative, and take decisive action.
+No one is coming to save you, it is up to you to take control of your own health. If I had followed the mainstream advice on managing my type 1 diabetes, I would have been trapped in a cycle of blood sugar spikes, insulin dependence, and declining well-being. Instead, I chose to think for myself, challenge the narrative, and take decisive action.
 </C>
 
-<C>**You have that choice too.**</C>
+<C>
+**You have that choice too.**
+</C>
+


### PR DESCRIPTION
The pull request focuses on restoring MDX seed files to a specific previous version identified by the commit hash 4b72bb78. This involves reverting changes in three MDX files located within the `packages/seeder/src/data/mdx` directory. Specifically, the `bounce-tracking.mdx` file underwent two modifications, the `branded-types.mdx` file experienced three changes, and the `cholesterol.mdx` file had two alterations. The restoration process involves ensuring that the content and structure of these files match exactly what was present in the specified commit, effectively undoing any subsequent modifications that might have been introduced after that commit. This action is typically taken to revert unintended changes or to restore a known good state of the seed data, ensuring consistency and correctness in the data seeding process. The focus is on maintaining the integrity of the seed data as originally intended in the specified version, which is crucial for any downstream processes or applications relying on this data.
  
  
  

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>